### PR TITLE
Fix: Run release workflow after cicd workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: Release
 
 on:
   workflow_run:
-    workflows: ["Build and Test"]
+    workflows: ["cicd"]
     types: [completed]
   workflow_dispatch: #Allow manual trigger of workflow
 


### PR DESCRIPTION
Modified the trigger event workflow from Build and Test to cicd, so now the release workflow should only run after the CI/CD workflow has run successfully