### PR TITLE
Fix: remove push event condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-24.04 # matches version in droplets
 
     steps:


### PR DESCRIPTION
Workflow wouldn't run after the successful completion of the CI/CD workflow, because it needed to happen in connection with a push event also. This clause was there so we could run the "Build and Test" workflow without triggering the release workflow. 