### PR TITLE
Fix https

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -99,9 +99,10 @@ jobs:
         run: >
           ssh $SSH_USER@$SSH_HOST
           -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no
-          "DOCKER_USERNAME='$DOCKER_USERNAME' ConnectionStrings__DefaultConnection='$CONNECTION_STRING' docker stack deploy minitwit -c /root/minitwit_stack.yml"
+          "DOCKER_USERNAME='$DOCKER_USERNAME' CADDY_EMAIL='$CADDY_EMAIL' ConnectionStrings__DefaultConnection='$CONNECTION_STRING' docker stack deploy minitwit -c /root/minitwit_stack.yml"
         env:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_HOST: ${{ secrets.SSH_HOST }}
           DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}
           CONNECTION_STRING: ${{secrets.CONNECTION_STRING}}
+          CADDY_EMAIL: ${{secrets.CADDY_EMAIL}}

--- a/itu-minitwit/deploy_swarm.sh
+++ b/itu-minitwit/deploy_swarm.sh
@@ -8,5 +8,5 @@ if [[ $1 == "build" ]]; then
 fi
 
 docker stack deploy minitwit -c ./infrastructure/docker_swarm/local_stack/minitwit_stack.yml --detach=false 
-echo "go to MiniTwit: http://127.0.0.1:8080"
+echo "go to MiniTwit: https://minitwit.localhost"
 echo "go to Grafana: http://127.0.0.1:3000"

--- a/itu-minitwit/infrastructure/docker_swarm/local_stack/minitwit_stack.yml
+++ b/itu-minitwit/infrastructure/docker_swarm/local_stack/minitwit_stack.yml
@@ -7,10 +7,22 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development #specified for clarity
       - ConnectionStrings__DefaultConnection=Host=database;Port=5432;Database=default_database;Username=username;Password=password
-    ports:
-      - '8080:8080'
     deploy:
       replicas: 4
+      labels:
+        # Enable Service discovery for Traefik
+        - "traefik.enable=true"
+        # Define the WHoami router rule
+        - "traefik.http.routers.whoami.rule=Host(`whoami.swarm.localhost`)"
+        # Expose Whoami on the HTTPS entrypoint
+        - "traefik.http.routers.whoami.entrypoints=websecure"
+        # Enable TLS
+        - "traefik.http.routers.whoami.tls=true"
+        # Expose the whoami port number to Traefik
+        - traefik.http.services.whoami.loadbalancer.server.port=80
+    networks:
+      - traefik_proxy
+      - default
 
 
   prometheus:
@@ -62,14 +74,81 @@ services:
       constraints: [node.role == manager]
 
 
-#  loadbalancer:
-#    image: nginx
-#    ports:
-#      - '80:80'
-#    volumes:
-#      - /loadbalancer:/etc/nginx/conf.d
-#    deploy:
-#      replicas: 2
+  traefik:
+    image: traefik:v3.7
+    networks:
+      - traefik_proxy
+    ports:
+      - target: 80
+        published: 8080
+        protocol: tcp
+        mode: host
+      - target: 443
+        published: 443
+        protocol: tcp
+        mode: host
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro   
+    command:
+       # HTTP EntryPoint
+      - "--entrypoints.web.address=:80"
+
+      # Configure HTTP to HTTPS Redirection
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
+
+      # HTTPS EntryPoint
+      - "--entrypoints.websecure.address=:443"
+      - "--entrypoints.websecure.http.tls=true"
+
+      # Attach dynamic TLS file
+      - "--providers.file.filename=/local_stack/tls.yaml"
+
+      # Providers
+
+      # Enable the Docker Swarm provider (instead of Docker provider)
+      - "--providers.swarm.endpoint=unix:///var/run/docker.sock"
+
+      # Watch for Swarm service changes (requires socket access)
+      - "--providers.swarm.watch=true"
+
+      # Recommended: Don't expose services by default; require explicit labels
+      - "--providers.swarm.exposedbydefault=false"
+
+      # Specify the default network for Traefik to connect to services
+      - "--providers.swarm.network=traefik_traefik_proxy"
+
+      # API & Dashboard
+      - "--api.dashboard=true" # Enable the dashboard
+      - "--api.insecure=false" # Explicitly disable insecure API mod
+
+      # Observability
+      - "--log.level=INFO" # Set the Log Level e.g INFO, DEBUG
+      - "--accesslog=true" # Enable Access Logs
+      - "--metrics.prometheus=true"  # Enable Prometheus
+
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints: [node.role == manager]
+
+    labels:
+        - "traefik.enable=true"
+
+        # Dashboard router
+        - "traefik.http.routers.dashboard.rule=Host(`dashboard.swarm.localhost`)"
+        - "traefik.http.routers.dashboard.entrypoints=websecure"
+        - "traefik.http.routers.dashboard.service=api@internal"
+        - "traefik.http.routers.dashboard.tls=true"
+
+        # Basic‑auth middleware
+        - "traefik.http.middlewares.dashboard-auth.basicauth.users=admin:$$apr1$$GVMOkziy$$lU2qWuxwtlVI8tFVfwieT0"
+        - "traefik.http.routers.dashboard.middlewares=dashboard-auth@swarm"
+
+        # Service hint
+        - "traefik.http.services.traefik.loadbalancer.server.port=8080"
 
   database:
     image: "postgres:latest"
@@ -90,3 +169,9 @@ volumes:
   loki-storage: {}
   grafana-storage: {} 
   prometheus-storage: {}
+  cert-storage: {}
+
+networks:
+  traefik_proxy:
+    driver: overlay
+    attachable: true

--- a/itu-minitwit/infrastructure/docker_swarm/local_stack/minitwit_stack.yml
+++ b/itu-minitwit/infrastructure/docker_swarm/local_stack/minitwit_stack.yml
@@ -34,22 +34,23 @@ services:
     ports:
       - "9090:9090"
     deploy:
-     replicas: 1
-     placement:
+      replicas: 1
+      placement:
         constraints: [node.role == manager]
 
-  alloy: 
+
+  alloy:
     image: alloy_image
-    command: 
+    command:
       - "run"
       - "/etc/alloy/config.alloy"
-    volumes: 
-      - /var/run/docker.sock:/var/run/docker.sock 
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     deploy:
       mode: global
 
 
-  loki: 
+  loki:
     image: loki_image
     ports:
       - "3100:3100"
@@ -57,9 +58,9 @@ services:
       - loki-storage:/loki
     command: "--config.file=/etc/loki/loki.yml"
     deploy:
-     replicas: 1
-     placement:
-      constraints: [node.role == manager]
+      replicas: 1
+      placement:
+        constraints: [node.role == manager]
 
 
   grafana:
@@ -69,11 +70,12 @@ services:
     volumes:
       - grafana-storage:/var/lib/grafana
     deploy:
-     replicas: 1
-     placement:
-      constraints: [node.role == manager]
+      replicas: 1
+      placement:
+        constraints: [node.role == manager]
 
 
+  #For the traefik part we followed this guide: https://doc.traefik.io/traefik/setup/swarm/
   traefik:
     image: traefik:v3.7
     networks:
@@ -88,9 +90,10 @@ services:
         protocol: tcp
         mode: host
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro   
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./tls.yaml:/local_stack/tls.yaml:ro
     command:
-       # HTTP EntryPoint
+      # HTTP EntryPoint
       - "--entrypoints.web.address=:80"
 
       # Configure HTTP to HTTPS Redirection
@@ -100,14 +103,15 @@ services:
 
       # HTTPS EntryPoint
       - "--entrypoints.websecure.address=:443"
-      - "--entrypoints.websecure.http.tls=true"
 
       # Attach dynamic TLS file
-      - "--providers.file.filename=/local_stack/tls.yaml"
+      - "--entrypoints.websecure.http.tls=true"
 
-      # Providers
+
+     # Providers
 
       # Enable the Docker Swarm provider (instead of Docker provider)
+      - "--providers.file.filename=/local_stack/tls.yaml"
       - "--providers.swarm.endpoint=unix:///var/run/docker.sock"
 
       # Watch for Swarm service changes (requires socket access)
@@ -133,8 +137,7 @@ services:
       replicas: 1
       placement:
         constraints: [node.role == manager]
-
-    labels:
+      labels:
         - "traefik.enable=true"
 
         # Dashboard router
@@ -150,14 +153,15 @@ services:
         # Service hint
         - "traefik.http.services.traefik.loadbalancer.server.port=8080"
 
+
   database:
     image: "postgres:latest"
     ports:
       - 5433:5432
     environment:
-      POSTGRES_USER: username   
-      POSTGRES_PASSWORD: password 
-      POSTGRES_DB: default_database 
+      POSTGRES_USER: username
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: default_database
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U username -d default_database"]
       interval: 5s
@@ -167,7 +171,7 @@ services:
 
 volumes:
   loki-storage: {}
-  grafana-storage: {} 
+  grafana-storage: {}
   prometheus-storage: {}
   cert-storage: {}
 

--- a/itu-minitwit/infrastructure/docker_swarm/local_stack/minitwit_stack.yml
+++ b/itu-minitwit/infrastructure/docker_swarm/local_stack/minitwit_stack.yml
@@ -7,22 +7,14 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development #specified for clarity
       - ConnectionStrings__DefaultConnection=Host=database;Port=5432;Database=default_database;Username=username;Password=password
+    networks:
+      - caddy
+      - default
     deploy:
       replicas: 4
       labels:
-        # Enable Service discovery for Traefik
-        - "traefik.enable=true"
-        # Define the WHoami router rule
-        - "traefik.http.routers.whoami.rule=Host(`whoami.swarm.localhost`)"
-        # Expose Whoami on the HTTPS entrypoint
-        - "traefik.http.routers.whoami.entrypoints=websecure"
-        # Enable TLS
-        - "traefik.http.routers.whoami.tls=true"
-        # Expose the whoami port number to Traefik
-        - traefik.http.services.whoami.loadbalancer.server.port=80
-    networks:
-      - traefik_proxy
-      - default
+        caddy: minitwit.localhost # host name 
+        caddy.reverse_proxy: "{{upstreams 8080}}" #where to send traffic
 
 
   prometheus:
@@ -74,81 +66,6 @@ services:
       constraints: [node.role == manager]
 
 
-  traefik:
-    image: traefik:v3.7
-    networks:
-      - traefik_proxy
-    ports:
-      - target: 80
-        published: 8080
-        protocol: tcp
-        mode: host
-      - target: 443
-        published: 443
-        protocol: tcp
-        mode: host
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro   
-    command:
-       # HTTP EntryPoint
-      - "--entrypoints.web.address=:80"
-
-      # Configure HTTP to HTTPS Redirection
-      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
-      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
-      - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
-
-      # HTTPS EntryPoint
-      - "--entrypoints.websecure.address=:443"
-      - "--entrypoints.websecure.http.tls=true"
-
-      # Attach dynamic TLS file
-      - "--providers.file.filename=/local_stack/tls.yaml"
-
-      # Providers
-
-      # Enable the Docker Swarm provider (instead of Docker provider)
-      - "--providers.swarm.endpoint=unix:///var/run/docker.sock"
-
-      # Watch for Swarm service changes (requires socket access)
-      - "--providers.swarm.watch=true"
-
-      # Recommended: Don't expose services by default; require explicit labels
-      - "--providers.swarm.exposedbydefault=false"
-
-      # Specify the default network for Traefik to connect to services
-      - "--providers.swarm.network=traefik_traefik_proxy"
-
-      # API & Dashboard
-      - "--api.dashboard=true" # Enable the dashboard
-      - "--api.insecure=false" # Explicitly disable insecure API mod
-
-      # Observability
-      - "--log.level=INFO" # Set the Log Level e.g INFO, DEBUG
-      - "--accesslog=true" # Enable Access Logs
-      - "--metrics.prometheus=true"  # Enable Prometheus
-
-    deploy:
-      mode: replicated
-      replicas: 1
-      placement:
-        constraints: [node.role == manager]
-
-    labels:
-        - "traefik.enable=true"
-
-        # Dashboard router
-        - "traefik.http.routers.dashboard.rule=Host(`dashboard.swarm.localhost`)"
-        - "traefik.http.routers.dashboard.entrypoints=websecure"
-        - "traefik.http.routers.dashboard.service=api@internal"
-        - "traefik.http.routers.dashboard.tls=true"
-
-        # Basic‑auth middleware
-        - "traefik.http.middlewares.dashboard-auth.basicauth.users=admin:$$apr1$$GVMOkziy$$lU2qWuxwtlVI8tFVfwieT0"
-        - "traefik.http.routers.dashboard.middlewares=dashboard-auth@swarm"
-
-        # Service hint
-        - "traefik.http.services.traefik.loadbalancer.server.port=8080"
 
   database:
     image: "postgres:latest"
@@ -164,14 +81,37 @@ services:
       timeout: 5s
       retries: 5
 
+  caddy:
+    image: lucaslorentz/caddy-docker-proxy:ci-alpine
+    ports:
+    - target: 80
+      published: 80
+      protocol: tcp
+      mode: host
+    - target: 443
+      published: 443
+      protocol: tcp
+      mode: host
+    environment:
+      - CADDY_INGRESS_NETWORKS=minitwit_caddy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - caddy_data:/data
+    restart: unless-stopped
+    networks:
+      - caddy
+    deploy:
+      replicas: 1
+      placement:
+        constraints: [node.role == manager]
 
 volumes:
   loki-storage: {}
   grafana-storage: {} 
   prometheus-storage: {}
-  cert-storage: {}
+  caddy_data: {}
 
 networks:
-  traefik_proxy:
+  caddy:
     driver: overlay
     attachable: true

--- a/itu-minitwit/infrastructure/docker_swarm/local_stack/tls.yaml
+++ b/itu-minitwit/infrastructure/docker_swarm/local_stack/tls.yaml
@@ -1,5 +1,0 @@
-# dynamic/tls.yaml
-tls:
-  certificates:
-    - certFile: /certs/local.crt
-      keyFile:  /certs/local.key

--- a/itu-minitwit/infrastructure/docker_swarm/local_stack/tls.yaml
+++ b/itu-minitwit/infrastructure/docker_swarm/local_stack/tls.yaml
@@ -1,0 +1,5 @@
+# dynamic/tls.yaml
+tls:
+  certificates:
+    - certFile: /certs/local.crt
+      keyFile:  /certs/local.key

--- a/itu-minitwit/infrastructure/docker_swarm/stack/minitwit_stack.yml
+++ b/itu-minitwit/infrastructure/docker_swarm/stack/minitwit_stack.yml
@@ -92,7 +92,7 @@ services:
         constraints:
           - node.hostname == minitwit-swarm-leader
       labels:
-        caddy.email: marho@itu.dk
+        caddy.email: ${CADDY_EMAIL}
 
 volumes:
   loki-storage: {}

--- a/itu-minitwit/infrastructure/docker_swarm/stack/minitwit_stack.yml
+++ b/itu-minitwit/infrastructure/docker_swarm/stack/minitwit_stack.yml
@@ -91,6 +91,8 @@ services:
       placement:
         constraints:
           - node.hostname == minitwit-swarm-leader
+      labels:
+        caddy.email: marho@itu.dk
 
 volumes:
   loki-storage: {}

--- a/itu-minitwit/infrastructure/docker_swarm/stack/minitwit_stack.yml
+++ b/itu-minitwit/infrastructure/docker_swarm/stack/minitwit_stack.yml
@@ -10,16 +10,13 @@ services:
     ports:
       - '8080:8080'
     networks:
-      - traefik_proxy
+      - caddy
       - default
     deploy:
       replicas: 4
-      labels: #adding traefik
-        - "traefik.enable=true"
-        - "traefik.http.routers.minitwit.rule=Host(`${DOMAIN}`)"
-        - "traefik.http.routers.minitwit.entrypoints=websecure"
-        - "traefik.http.routers.minitwit.tls.certresolver=letsencrypt"
-        - "traefik.http.services.minitwit.loadbalancer.server.port=8080"
+      labels:
+        caddy: devbobs.tech # host name 
+        caddy.reverse_proxy: "{{upstreams 8080}}" #where to send traffic
 
   prometheus:
     image: ${DOCKER_USERNAME}/minitwit-prometheus
@@ -70,78 +67,38 @@ services:
         constraints:
           - node.hostname == minitwit-swarm-leader
 
-#Followed this guide https://doc.traefik.io/traefik/setup/swarm/
-  traefik:
-    image: traefik:v3.7
-    networks:
-      - traefik_proxy
+  caddy:
+    image: lucaslorentz/caddy-docker-proxy:ci-alpine
     ports:
-      - target: 80
-        published: 80
-        protocol: tcp
-        mode: host
-      - target: 443
-        published: 443
-        protocol: tcp
-        mode: host
+    - target: 80
+      published: 80
+      protocol: tcp
+      mode: host
+    - target: 443
+      published: 443
+      protocol: tcp
+      mode: host
+    environment:
+      - CADDY_INGRESS_NETWORKS=minitwit_caddy
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - traefik-certificates:/certificates
-    command:
-      # HTTP EntryPoint
-      - "--entrypoints.web.address=:80"
-
-      # Redirection from HTTP to HTTPs
-      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
-      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
-      - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
-
-      # HTTPS EntryPoint
-      - "--entrypoints.websecure.address=:443"
-
-      # Setting of swarm network
-      - "--providers.swarm.endpoint=unix:///var/run/docker.sock"
-      - "--providers.swarm.watch=true"
-      - "--providers.swarm.exposedbydefault=false"
-      - "--providers.swarm.network=traefik_traefik_proxy"
-
-      # Certificates
-      - "--certificatesresolvers.letsencrypt.acme.tlschallenge=true"
-      - "--certificatesresolvers.letsencrypt.acme.email=${CERT_EMAIL}" #Was ACME_EMAIL if needed to change back
-      - "--certificatesresolvers.letsencrypt.acme.storage=/certificates/acme.json"
-
-      # API & Dashboard
-      - "--api.dashboard=true"
-      - "--api.insecure=false"
-
-      # Enable prometheus and logs
-      - "--log.level=INFO" # Set the Log Level e.g INFO, DEBUG
-      - "--accesslog=true" # Enable Access Logs
-      - "--metrics.prometheus=true"  # Enable Prometheus
+      - /var/run/docker.sock:/var/run/docker.sock
+      - caddy_data:/data
+    restart: unless-stopped
+    networks:
+      - caddy
     deploy:
-      mode: replicated
       replicas: 1
       placement:
         constraints:
           - node.hostname == minitwit-swarm-leader
-      labels:
-        # setting up the dashboard for the leader
-        - "traefik.enable=true"
-        - "traefik.http.routers.dashboard.rule=Host(`dashboard.${DOMAIN}`)"
-        - "traefik.http.routers.dashboard.entrypoints=websecure"
-        - "traefik.http.routers.dashboard.service=api@internal"
-        - "traefik.http.routers.dashboard.tls.certresolver=letsencrypt"
-        - "traefik.http.middlewares.dashboard-auth.basicauth.users=${TRAEFIK_DASHBOARD_CREDENTIALS}"
-        - "traefik.http.routers.dashboard.middlewares=dashboard-auth@swarm"
-        - "traefik.http.services.traefik.loadbalancer.server.port=8080"
 
 volumes:
   loki-storage: {}
   grafana-storage: {} 
   prometheus-storage: {}
-  traefik-certificates: {}
+  caddy_data: {}
 
 networks:
-  traefik_proxy:
+  caddy:
     driver: overlay
     attachable: true

--- a/itu-minitwit/infrastructure/docker_swarm/stack/minitwit_stack.yml
+++ b/itu-minitwit/infrastructure/docker_swarm/stack/minitwit_stack.yml
@@ -9,8 +9,17 @@ services:
       - ConnectionStrings__DefaultConnection=${ConnectionStrings__DefaultConnection}
     ports:
       - '8080:8080'
+    networks:
+      - traefik_proxy
+      - default
     deploy:
       replicas: 4
+      labels: #adding traefik
+        - "traefik.enable=true"
+        - "traefik.http.routers.minitwit.rule=Host(`${DOMAIN}`)"
+        - "traefik.http.routers.minitwit.entrypoints=websecure"
+        - "traefik.http.routers.minitwit.tls.certresolver=letsencrypt"
+        - "traefik.http.services.minitwit.loadbalancer.server.port=8080"
 
   prometheus:
     image: ${DOCKER_USERNAME}/minitwit-prometheus
@@ -21,23 +30,22 @@ services:
     ports:
       - "9090:9090"
     deploy:
-     replicas: 1
-     placement:
-        constraints: 
+      replicas: 1
+      placement:
+        constraints:
           - node.hostname == minitwit-swarm-leader
 
-  alloy: 
+  alloy:
     image: ${DOCKER_USERNAME}/minitwit-alloy
-    command: 
+    command:
       - "run"
       - "/etc/alloy/config.alloy"
-    volumes: 
-      - /var/run/docker.sock:/var/run/docker.sock 
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     deploy:
       mode: global
 
-
-  loki: 
+  loki:
     image: ${DOCKER_USERNAME}/minitwit-loki
     ports:
       - "3100:3100"
@@ -45,11 +53,10 @@ services:
       - loki-storage:/loki
     command: "--config.file=/etc/loki/loki.yml"
     deploy:
-     replicas: 1
-     placement:
-      constraints:
-        - node.hostname == minitwit-swarm-leader
-
+      replicas: 1
+      placement:
+        constraints:
+          - node.hostname == minitwit-swarm-leader
 
   grafana:
     image: ${DOCKER_USERNAME}/minitwit-grafana
@@ -58,23 +65,83 @@ services:
     volumes:
       - grafana-storage:/var/lib/grafana
     deploy:
-     replicas: 1
-     placement:
-      constraints:
-        - node.hostname == minitwit-swarm-leader
+      replicas: 1
+      placement:
+        constraints:
+          - node.hostname == minitwit-swarm-leader
 
-
-  loadbalancer:
-    image: nginx
+#Followed this guide https://doc.traefik.io/traefik/setup/swarm/
+  traefik:
+    image: traefik:v3.7
+    networks:
+      - traefik_proxy
     ports:
-      - '80:80'
-      - '443:443'
+      - target: 80
+        published: 80
+        protocol: tcp
+        mode: host
+      - target: 443
+        published: 443
+        protocol: tcp
+        mode: host
     volumes:
-      - /loadbalancer:/etc/nginx/conf.d
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - traefik-certificates:/certificates
+    command:
+      # HTTP EntryPoint
+      - "--entrypoints.web.address=:80"
+
+      # Redirection from HTTP to HTTPs
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
+
+      # HTTPS EntryPoint
+      - "--entrypoints.websecure.address=:443"
+
+      # Setting of swarm network
+      - "--providers.swarm.endpoint=unix:///var/run/docker.sock"
+      - "--providers.swarm.watch=true"
+      - "--providers.swarm.exposedbydefault=false"
+      - "--providers.swarm.network=traefik_traefik_proxy"
+
+      # Certificates
+      - "--certificatesresolvers.letsencrypt.acme.tlschallenge=true"
+      - "--certificatesresolvers.letsencrypt.acme.email=${CERT_EMAIL}" #Was ACME_EMAIL if needed to change back
+      - "--certificatesresolvers.letsencrypt.acme.storage=/certificates/acme.json"
+
+      # API & Dashboard
+      - "--api.dashboard=true"
+      - "--api.insecure=false"
+
+      # Enable prometheus and logs
+      - "--log.level=INFO" # Set the Log Level e.g INFO, DEBUG
+      - "--accesslog=true" # Enable Access Logs
+      - "--metrics.prometheus=true"  # Enable Prometheus
     deploy:
-      replicas: 2
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints:
+          - node.hostname == minitwit-swarm-leader
+      labels:
+        # setting up the dashboard for the leader
+        - "traefik.enable=true"
+        - "traefik.http.routers.dashboard.rule=Host(`dashboard.${DOMAIN}`)"
+        - "traefik.http.routers.dashboard.entrypoints=websecure"
+        - "traefik.http.routers.dashboard.service=api@internal"
+        - "traefik.http.routers.dashboard.tls.certresolver=letsencrypt"
+        - "traefik.http.middlewares.dashboard-auth.basicauth.users=${TRAEFIK_DASHBOARD_CREDENTIALS}"
+        - "traefik.http.routers.dashboard.middlewares=dashboard-auth@swarm"
+        - "traefik.http.services.traefik.loadbalancer.server.port=8080"
 
 volumes:
   loki-storage: {}
   grafana-storage: {} 
   prometheus-storage: {}
+  traefik-certificates: {}
+
+networks:
+  traefik_proxy:
+    driver: overlay
+    attachable: true

--- a/itu-minitwit/infrastructure/docker_swarm/stack/minitwit_stack.yml
+++ b/itu-minitwit/infrastructure/docker_swarm/stack/minitwit_stack.yml
@@ -69,7 +69,7 @@ services:
 
   caddy:
     image: lucaslorentz/caddy-docker-proxy:ci-alpine
-    ports:
+    ports: #Debugged with Claude AI
     - target: 80
       published: 80
       protocol: tcp

--- a/notebook.md
+++ b/notebook.md
@@ -213,3 +213,7 @@ To run the tests against the api, run `pytest minitwit_sim_api_test.py` (while t
 # Lecutre 11
 14/04: 12:00: We decided to go with docker swarm and terraform as out guarantees of higher availanility, as we had a choice between this and the dual load balancers. We are a bit behind, from the previous weeks and we deem it easier to implement it in a pile, than doing a lot of small steps, some which would potentially be redundant with new features and tools.
 
+
+
+# Lecture 13
+13/05 9:30: Trying to fix https. Tried traefik but could not get it to work. Then switched to Caddy, which for now works locally. We will still have a single point of failure as the floating ip will be pointing to the leader only, but now the leader should be able to ude caddy to take in request on port 80 and 433 and decrypt. It would be: internet -> floating ip -> leader 80 or 433 -> caddy -> minitwit containers (load balanced). We have to check up on this exactly!

--- a/notebook.md
+++ b/notebook.md
@@ -223,4 +223,5 @@ To run the tests against the api, run `pytest minitwit_sim_api_test.py` (while t
 - This did indeed fix the http:devbobs.tech, but there is still problems with the https:devbobs.tech. We suspect that this is due to tls certificates. 
 
 13/05 9:30: Trying to fix https. Tried traefik but could not get it to work. Then switched to Caddy, which for now works locally. We will still have a single point of failure as the floating ip will be pointing to the leader only, but now the leader should be able to ude caddy to take in request on port 80 and 433 and decrypt. It would be: internet -> floating ip -> leader 80 or 433 -> caddy -> minitwit containers (load balanced). We have to check up on this exactly!
+- link to Docker-Caddy github repository: https://github.com/lucaslorentz/caddy-docker-proxy
 


### PR DESCRIPTION
I think we can try to use Caddy for https. **I used this https://github.com/lucaslorentz/caddy-docker-proxy**

I tried Treafik first, but could not get it to work.. :(
Then tried Caddy: https://techroads.org/building-a-caddy-container-stack-for-easy-https-with-docker-and-ghost/

Claude was used to debug til Caddy setup