### PR TITLE
Fix alloy for worker nodes

### DIFF
--- a/itu-minitwit/deploy_swarm.sh
+++ b/itu-minitwit/deploy_swarm.sh
@@ -10,3 +10,4 @@ fi
 docker stack deploy minitwit -c ./infrastructure/docker_swarm/local_stack/minitwit_stack.yml --detach=false 
 echo "go to MiniTwit: https://minitwit.localhost"
 echo "go to Grafana: http://127.0.0.1:3000"
+echo "go to Alloy UI: http://127.0.0.1:12345"

--- a/itu-minitwit/infrastructure/docker_swarm/local_stack/minitwit_stack.yml
+++ b/itu-minitwit/infrastructure/docker_swarm/local_stack/minitwit_stack.yml
@@ -40,7 +40,7 @@ services:
       - run
       - --server.http.listen-addr=0.0.0.0:12345
       - --storage.path=/var/lib/alloy/data
-      - /etc/alloy/swarm.alloy
+      - /etc/alloy/newconfig.alloy
     ports: 
       - 12345:12345
     deploy:

--- a/itu-minitwit/infrastructure/docker_swarm/stack/minitwit_stack.yml
+++ b/itu-minitwit/infrastructure/docker_swarm/stack/minitwit_stack.yml
@@ -41,7 +41,7 @@ services:
       - run
       - --server.http.listen-addr=0.0.0.0:12345
       - --storage.path=/var/lib/alloy/data
-      - /etc/alloy/swarm.alloy
+      - /etc/alloy/newconfig.alloy
     ports: 
       - 12345:12345
     deploy:

--- a/itu-minitwit/monitoring/alloy/Dockerfile
+++ b/itu-minitwit/monitoring/alloy/Dockerfile
@@ -1,3 +1,3 @@
 #figure out which version to use
 FROM grafana/alloy:latest 
-COPY ./swarm.alloy /etc/alloy/swarm.alloy
+COPY ./newconfig.alloy /etc/alloy/newconfig.alloy

--- a/itu-minitwit/monitoring/alloy/newconfig.alloy
+++ b/itu-minitwit/monitoring/alloy/newconfig.alloy
@@ -1,0 +1,26 @@
+discovery.docker "local" {
+  host             = "unix:///var/run/docker.sock"
+  refresh_interval = "15s"
+}
+
+discovery.relabel "swarm_logs" {
+  targets = discovery.docker.local.targets
+
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_swarm_service_name"]
+    target_label  = "service"
+  }
+
+}
+
+loki.source.docker "swarm_tasks" {
+  host       = "unix:///var/run/docker.sock"
+  targets    = discovery.relabel.swarm_logs.output
+  forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+}

--- a/notebook.md
+++ b/notebook.md
@@ -225,3 +225,10 @@ To run the tests against the api, run `pytest minitwit_sim_api_test.py` (while t
 13/05 9:30: Trying to fix https. Tried traefik but could not get it to work. Then switched to Caddy, which for now works locally. We will still have a single point of failure as the floating ip will be pointing to the leader only, but now the leader should be able to ude caddy to take in request on port 80 and 433 and decrypt. It would be: internet -> floating ip -> leader 80 or 433 -> caddy -> minitwit containers (load balanced). We have to check up on this exactly!
 - link to Docker-Caddy github repository: https://github.com/lucaslorentz/caddy-docker-proxy
 
+
+17/5 - 12:15: No logs from minitwit service appears in grafana after deploying new alloy config
+- After updating the alloy service in our production environment, the logs from minitwit dissappeared. Turns out that the worker nodes, which contains the minitwit service, doens't have the needed permissions to use the discovery.dockerswarm module. This was confirmed by running the command `docker service logs minitwit_alloy 2>&1 | grep -i "error\|config\|failed"`, which output included the following error message numerous time: `minitwit_alloy.0.nl5a73h8kas3@minitwit-swarm-worker-1    | ts=2026-05-17T10:03:59 level=error msg="Unable to refresh target groups" component_path=/ component_id=discovery.dockerswarm.swarm err="error while listing swarm services: Error response from daemon: This node is not a swarm manager. Worker nodes can't be used to view or modify cluster state. Please run this command on a manager node or promote the current node to a manager."`
+
+- In less technincal terms, the discovery.dockerswarm module attempts to discover the tasks present on each node via querying the cluster state, but worker nodes are not permitted to view the cluster state. This means the alloy service, even if it's deployed as a global service, is prohibited from discovering the tasks on our worker nodes. 
+
+- To solve this issue, we had to switch back the the old discovery.docker module in our alloy config. 


### PR DESCRIPTION
Replaced the discovery module used by alloy. This should allow our alloy service to work on our worker nodes, so that we can get logs from our minitwit service